### PR TITLE
Clean-up of doctype in prettyXML.

### DIFF
--- a/generatePoaXml.py
+++ b/generatePoaXml.py
@@ -169,15 +169,20 @@ class eLife2XML(object):
         print self.root
 
     def prettyXML(self):
-        doctype = minidom.getDOMImplementation('').createDocumentType(
-            'article', '-//NLM//DTD Journal Archiving and Interchange DTD v3.0 20080202//EN',
-            'http://dtd.nlm.nih.gov/archiving/3.0/archivearticle3.dtd')
+        publicId = '-//NLM//DTD Journal Archiving and Interchange DTD v3.0 20080202//EN'
+        systemId = 'http://dtd.nlm.nih.gov/archiving/3.0/archivearticle3.dtd'
+        encoding = 'utf-8'
+        namespaceURI = None
+        qualifiedName = "article"
+    
+        doctype = minidom.DocumentType(qualifiedName)
+        doctype._identified_mixin_init(publicId, systemId)
 
-        rough_string = ElementTree.tostring(self.root, 'utf-8')
+        rough_string = ElementTree.tostring(self.root, encoding)
         reparsed = minidom.parseString(rough_string)
         if doctype:
             reparsed.insertBefore(doctype, reparsed.documentElement)
-        return reparsed.toprettyxml(indent="\t")
+        return reparsed.toprettyxml(indent="\t", encoding = encoding)
 
 class ContributorAffiliation():
     phone = None


### PR DESCRIPTION
In reference to https://github.com/elifesciences/elife-poa-xml-generation/issues/13  Comments welcome whether the values in prettyXML should be object attributes.

<!---
@huboard:{"order":7.96875}
-->
