### PR TITLE
Permissions

### DIFF
--- a/generatePoaXml.py
+++ b/generatePoaXml.py
@@ -248,7 +248,7 @@ class eLife2XML(object):
         reparsed = minidom.parseString(rough_string)
         if doctype:
             reparsed.insertBefore(doctype, reparsed.documentElement)
-        return reparsed.toprettyxml(indent="\t", encoding = encoding)
+        return reparsed.toprettyxml(indent="\t")
 
 class ContributorAffiliation():
     phone = None


### PR DESCRIPTION
To note: the © should display correctly after removing encoding in the prettyXML(). Fixes #27.
