### PR TITLE
Do not add affiliation department value if it is a blank string.

### DIFF
--- a/xml_generation.py
+++ b/xml_generation.py
@@ -137,7 +137,9 @@ def set_author_info(article, article_id):
 			author = eLifePOSContributor(author_type, last_name, first_name)
 			affiliation = ContributorAffiliation()
 
-			affiliation.department = get_author_department(article_id, author_id)
+			department = get_author_department(article_id, author_id)
+			if department.strip() != "":
+				affiliation.department = department
 			affiliation.institution = get_author_institution(article_id, author_id)
 			affiliation.city = get_author_city(article_id, author_id)
 			affiliation.country = get_author_country(article_id, author_id)
@@ -180,7 +182,9 @@ def set_editor_info(article, article_id):
 		logger.info(str(type(get_me_id(article_id))))
 		editor.auth_id = `int(get_me_id(article_id))`
 		affiliation = ContributorAffiliation()
-		affiliation.department = get_me_department(article_id)
+		department =  get_me_department(article_id)
+		if department.strip() != "":
+			affiliation.department = department
 		affiliation.institution = get_me_institution(article_id)
 		affiliation.country = get_me_country(article_id)
 


### PR DESCRIPTION
Author and editor department tags are omitted from the XML if not present in the CSV data. This also results in no extra comma. Fixes #116.
