### PR TITLE
Poa v2

### DIFF
--- a/generateCrossrefXml.py
+++ b/generateCrossrefXml.py
@@ -86,7 +86,12 @@ class crossrefXML(object):
 
     def set_body(self, parent, poa_articles):
         self.body = SubElement(parent, 'body')
-        self.set_journal(self.body, poa_articles)
+        
+        for poa_article in poa_articles:
+            # Create a new journal record for each article
+            # Use a list of one for now
+            poa_article_list = [poa_article]
+            self.set_journal(self.body, poa_article_list)
         
     def get_pub_date(self, poa_article):
         """
@@ -109,7 +114,9 @@ class crossrefXML(object):
         
         #self.publication_date = self.set_date(self.journal_issue, poa_article, 'publication_date')
         
-        self.set_publication_date(self.journal_issue, self.pub_date)
+        # Get the issue date from the first article in the list when doing one article per issue
+        pub_date = self.get_pub_date(poa_articles[0])
+        self.set_publication_date(self.journal_issue, pub_date)
 
         self.journal_volume = SubElement(self.journal_issue, 'journal_volume')
         self.volume = SubElement(self.journal_volume, 'volume')
@@ -140,8 +147,8 @@ class crossrefXML(object):
             self.set_contributors(self.journal_article, poa_article, contrib_type)
         
         # Journal publication date
-        
-        self.set_publication_date(self.journal_article, self.get_pub_date(poa_article))
+        pub_date = self.get_pub_date(poa_article)
+        self.set_publication_date(self.journal_article, pub_date)
         
         self.publisher_item = SubElement(self.journal_article, 'publisher_item')
         self.identifier = SubElement(self.publisher_item, 'identifier')

--- a/generatePubMedXml.py
+++ b/generatePubMedXml.py
@@ -95,6 +95,22 @@ class pubMedPoaXML(object):
             pub_type = "aheadofprint"
         return pub_type
 
+    def get_has_date(self, poa_article, date_type):
+        """
+        Given an article object, determine whether the
+        date of type date_type's date object exists
+        Useful in generating Replaces tag for POA articles
+        """
+        
+        has_date = None
+        try:
+            poa_article.get_date(date_type).date
+            has_date = True
+        except:
+            has_date = False
+            
+        return has_date
+
     def set_journal(self, parent, poa_article):
         self.journal = SubElement(parent, "Journal")
         
@@ -134,8 +150,9 @@ class pubMedPoaXML(object):
         """
         Set the Replaces tag, if applicable
         """
-        # If the article is VoR and is was ever PoA
-        if poa_article.is_poa is False and poa_article.was_ever_poa is True:
+            
+        if ((poa_article.is_poa is False and poa_article.was_ever_poa is True)
+            or (poa_article.is_poa is True and self.get_has_date(poa_article, "pub") is True)):
             self.replaces = SubElement(parent, 'Replaces')
             self.replaces.set("IdType", "doi")
             self.replaces.text = poa_article.doi

--- a/generatePubMedXml.py
+++ b/generatePubMedXml.py
@@ -122,7 +122,12 @@ class pubMedPoaXML(object):
         if pub_type == "epublish":
             a_date = poa_article.get_date("pub").date
         else:
-            a_date = self.pub_date
+            # POA type, use the pub date if it is set, for when processing version 2, version 3, etc.
+            try:
+                a_date = poa_article.get_date("pub").date
+            except:
+                # Default use the run time date
+                a_date = self.pub_date
         self.set_pub_date(self.journal, a_date, pub_type)
 
     def set_replaces(self, parent, poa_article):
@@ -437,6 +442,8 @@ if __name__ == '__main__':
                     ,"generated_xml_output/elife04105.xml"
                     ,"generated_xml_output/elife04180.xml"
                     ,"generated_xml_output/elife04586.xml"
+                    ,"generated_xml_output/elife_poa_e00662.xml"
+                    ,"generated_xml_output/elife_poa_e02923.xml"
                     ]
     
     poa_articles = build_articles_from_article_xmls(article_xmls)
@@ -448,6 +455,13 @@ if __name__ == '__main__':
             or article.doi == '10.7554/eLife.03401'
             or article.doi == '10.7554/eLife.02935'):
             article.was_ever_poa = True
+        if article.doi == '10.7554/eLife.00662':
+            # Pretend it is v2 POA, which will have a pub date
+            date = datetime.datetime(2015, 2, 3)
+            pub_date = date.timetuple()
+            pub_type = "pub"
+            date_instance = eLifeDate(pub_type, pub_date)
+            article.add_date(date_instance)
     
     build_pubmed_xml_for_articles(poa_articles)
 


### PR DESCRIPTION
Generate Pubmed XML and generate crossref XML are modified for POA v2 feature. The bot sets the article object's pub date, if it is applicable. The XML generators here will use that date and set the appropriate Replaces tag for Pubmed.