### PR TITLE
Basic contributor affiliation parsing test, only sets the object's text ...

### DIFF
--- a/generatePoaXml.py
+++ b/generatePoaXml.py
@@ -512,7 +512,9 @@ class ContributorAffiliation():
     institution = None
     city = None 
     country = None
-
+    
+    text = None
+    
 class eLifePOSContributor():
     """
     Currently we are not sure that we can get an auth_id for 

--- a/generatePubMedXml.py
+++ b/generatePubMedXml.py
@@ -215,7 +215,7 @@ class pubMedPoaXML(object):
             # Only add one affiliation per author for Pubmed
             for aff in contributor.affiliations[:1]:
                 self.affiliation = SubElement(self.person_name, "Affiliation")
-                self.affiliation.text = aff
+                self.affiliation.text = aff.text
                 
             if contributor.orcid:
                 self.orcid = SubElement(self.person_name, "Identifier")

--- a/parsePoaXml.py
+++ b/parsePoaXml.py
@@ -176,7 +176,8 @@ def get_affs_from_xml(root, raw = False):
         aff_with_tags = convert_element_to_string(tag, '')
 
         # Remove all tags to leave the content behind
-        aff = strip_tags_from_string(aff_with_tags)
+        aff = {}
+        aff["text"] = strip_tags_from_string(aff_with_tags)
         
         affs[id] = aff
 
@@ -227,7 +228,8 @@ def get_contributor_from_contrib_group(root, affs, raw = False):
         # 1. Convert all content and tags to a string
         aff_with_tags = convert_element_to_string(tag, '')
         # 2. Remove all tags to leave the content behind
-        aff = strip_tags_from_string(aff_with_tags)
+        aff = {}
+        aff["text"] = strip_tags_from_string(aff_with_tags)
         
         affiliations.append(aff)
 
@@ -249,7 +251,9 @@ def get_contributor_from_contrib_group(root, affs, raw = False):
     contributor = eLifePOSContributor(contrib_type, surname, given_name, collab)
     
     for aff in affiliations:
-        contributor.set_affiliation(aff)
+        affiliation = ContributorAffiliation()
+        affiliation.text = aff["text"]
+        contributor.set_affiliation(affiliation)
     
     if root.get("corresp") == "yes":
         contributor.corresp = True

--- a/tests/features/parse.feature
+++ b/tests/features/parse.feature
@@ -106,6 +106,22 @@ Feature: Parse article XML
     | elife02935.xml        | contributor        | 53      | contrib_type   | author non-byline
     | elife02935.xml        | contributor        | 53      | surname        | Provenzano
 
+  Scenario: Parse article XML file contributor affiliations
+    Given I have the document <document>
+    When I build article from xml
+    And I set the object to article <property> index <index>
+    And I set the object to contributor affiliation index <aff_index>
+    And I have the attribute <attribute>
+    Then I have object attribute value <value>
+    
+  Examples:
+    | document              | property      | index | aff_index  | attribute      | value
+    | elife00013.xml        | contributor   | 0     | 0          | text           | Department of Molecular and Cell Biology, University of California, Berkeley, Berkeley, United States
+    | elife_poa_e06828.xml  | contributor   | 0     | 0          | text           | Department of Neuroscience, Perelman School of Medicine, University of Pennsylvania, Philadelphia, United States
+    | elife_poa_e02923.xml  | contributor   | 0     | 0          | text           | Department of Pediatrics, University of Colorado, Anschutz Medical Campus, Aurora, United States
+    | elife02935.xml        | contributor   | 0     | 0          | text           | Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom
+    
+
   Scenario: Parse article XML file dates
     Given I have the document <document>
     When I build article from xml

--- a/tests/features/parse_steps.py
+++ b/tests/features/parse_steps.py
@@ -79,7 +79,15 @@ def i_set_the_object_to_article_research_organisms_index(step, index):
 def i_set_the_object_to_article_date_type(step, type):
     world.object = world.article.get_date(type)
 
-
+@step(u'I set the object to contributor affiliation index (.*)')
+def i_set_the_object_to_contributor_affiliation(step, index):
+    print len(world.object.affiliations)
+    import json
+    #print json.dumps(world.object.affiliations)
+    world.object = world.object.affiliations[int(index)]
+    assert world.object is not None, \
+        "Got contributor affiliation object %s" % world.object
+    
 @step(u'I have object attribute value (.*)')
 def i_have_object_attribute_value(step, value):
     if value == "None":


### PR DESCRIPTION
...for generate pubmed and crossref.

This integrates the ContributorAffiliation object usage when an article XML is parsed. Previously it was just using a list of strings for the affiliation. For better integration with the coming new parser.