### PR TITLE
Volume from year

### DIFF
--- a/generateCrossrefXml.py
+++ b/generateCrossrefXml.py
@@ -33,7 +33,6 @@ class crossrefXML(object):
         self.contrib_types = ["author","on-behalf-of"]
         self.elife_journal_id = "eLife"
         self.elife_journal_title = "eLife"
-        self.elife_journal_volume = "4"
         self.elife_email_address = 'production@elifesciences.org'
         self.elife_epub_issn = "2050-084X"
         self.elife_publisher_name = "eLife Sciences Publications, Ltd"
@@ -132,7 +131,7 @@ class crossrefXML(object):
             if poa_article.volume:
                 self.volume.text = poa_article.volume
             else:
-                self.volume.text = self.elife_journal_volume
+                self.volume.text = elife_journal_volume(pub_date)
         
             # Add journal article
             self.set_journal_article(self.journal, poa_article)

--- a/generatePoaXml.py
+++ b/generatePoaXml.py
@@ -750,6 +750,17 @@ class ElifeDocumentType(minidom.DocumentType):
             writer.write("]")
         writer.write(">"+newl)
 
+def elife_journal_volume(pub_date):
+    """
+    volume value is based on the pub date year
+    pub_date is a python time object
+    """
+    try:
+        volume = str(pub_date.tm_year - 2011)
+    except:
+        volume = None
+    return volume
+
 def repl(m):
     # Convert hex to int to unicode character
     chr_code = int(m.group(1), 16)

--- a/generatePubMedXml.py
+++ b/generatePubMedXml.py
@@ -123,16 +123,6 @@ class pubMedPoaXML(object):
         self.issn = SubElement(self.journal, 'Issn')
         self.issn.text = self.elife_epub_issn
         
-        self.volume = SubElement(self.journal, "Volume")
-        # Use volume from the article unless not present then use the default
-        if poa_article.volume:
-            self.volume.text = poa_article.volume
-        else:
-            self.volume.text = self.elife_journal_volume
-
-        self.issue = SubElement(self.journal, "Issue")
-        self.issue.text = self.elife_journal_issue
-        
         #self.journal_pubdate = SubElement(self.journal, "PubDate")
         pub_type = self.get_pub_type(poa_article)
         if pub_type == "epublish":
@@ -144,6 +134,18 @@ class pubMedPoaXML(object):
             except:
                 # Default use the run time date
                 a_date = self.pub_date
+        
+        self.volume = SubElement(self.journal, "Volume")
+        # Use volume from the article unless not present then use the default
+        if poa_article.volume:
+            self.volume.text = poa_article.volume
+        else:
+            self.volume.text = elife_journal_volume(a_date)
+
+        self.issue = SubElement(self.journal, "Issue")
+        self.issue.text = self.elife_journal_issue
+        
+        # Add the pub date now
         self.set_pub_date(self.journal, a_date, pub_type)
 
     def set_replaces(self, parent, poa_article):


### PR DESCRIPTION
Pubmed and crossref generation. If the article XML has no volume tag, it calculates the volume based on the pub date instead of relying on a hard-coded volume value.