### PR TITLE
Remove wrapping <b> tag from pubmed article title, if present.

### DIFF
--- a/generatePubMedXml.py
+++ b/generatePubMedXml.py
@@ -169,6 +169,10 @@ class pubMedPoaXML(object):
         tag_converted_title = replace_tags(tag_converted_title, 'italic', 'i')
         tag_converted_title = replace_tags(tag_converted_title, 'bold', 'b')
         tag_converted_title = replace_tags(tag_converted_title, 'underline', 'u')
+        # Specific issue to remove b tag wrapping the entire title, if present
+        if tag_converted_title.startswith('<b>') and tag_converted_title.endswith('</b>'):
+            tag_converted_title = tag_converted_title.lstrip('<b>')
+            tag_converted_title = tag_converted_title.rstrip('</b>')
         tag_converted_title = escape_unmatched_angle_brackets(tag_converted_title)
         tagged_string = '<' + tag_name + '>' + tag_converted_title + '</' + tag_name + '>'
         reparsed = minidom.parseString(xml_escape_ampersand(tagged_string).encode('utf-8'))


### PR DESCRIPTION
Fixes http://jira.elifesciences.org:8080/browse/ELPP-1151 for elife-15716-v2.xml PubMed deposit.