### PR TITLE
Compatibility with elifetools 0.1.6 version.

### DIFF
--- a/parsePoaXml.py
+++ b/parsePoaXml.py
@@ -354,7 +354,7 @@ def build_article_from_xml(article_xml_filename, detail="brief"):
     contributors = build_contributors(author_contributors, contrib_type)
 
     contrib_type = "author non-byline"
-    authors = parser.authors(soup, contrib_type, detail)
+    authors = parser.authors_non_byline(soup, detail)
     contributors_non_byline = build_contributors(authors, contrib_type)
     article.contributors = contributors + contributors_non_byline
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ GitPython==0.3.2.1
 xlrd==0.9.3
 requests==2.5.3
 PyPDF2==1.20
-elifetools==0.1.5
+elifetools==0.1.6
 coverage==3.7.1
 arrow==0.4.4


### PR DESCRIPTION
Uses a new authors non-byline function which makes it compatible with older XML as well as the new kitchen sink XML that is on the way.