### PR TITLE
Wrap PDF decapitation with a function timeout.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyPDF2==1.20
 elifetools==0.1.7
 coverage==3.7.1
 arrow==0.4.4
+func_timeout==4.3.0


### PR DESCRIPTION
As a result of a zip package that may have stalled or taken a long time to decapitate the PDF file, this is an idea to wrap the function call with a timeout. It may allow the zip transformation to continue if a timeout is reached, and result in at least the ds.zip and article XML being produced.

I looked at options for ``subprocess.Popen()`` in ``decapitatePDF2.py`` to monitor the command execution, except monitoring for timeouts didn't seem to be very straightforward. If you see a better way of doing it, please feel free to suggest an alternative.

The resulting solution should also be added to the https://github.com/elifesciences/package-poa project, which will be the replacement for this library here.