### PR TITLE
Extend the decapitation timeout

### DIFF
--- a/transform-ejp-zip-to-hw-zip.py
+++ b/transform-ejp-zip-to-hw-zip.py
@@ -60,7 +60,7 @@ output_dir = settings.STAGING_TO_HW_DIR
 hw_ftp_dir = settings.FTP_TO_HW_DIR
 tmp_dir = settings.TMP_DIR
 decap_dir = settings.STAGING_DECAPITATE_PDF_DIR
-PDF_DECAPITATE_TIMEOUT = 120
+PDF_DECAPITATE_TIMEOUT = 900
 
 class manifestXML(object):
 


### PR DESCRIPTION
Extend the decapitation timeout from 120 to 900 seconds, so it does not prematurely cancel the process. Once the timeout is introduced into the bash script it calls, it could be this python function timeout should be removed anyway.